### PR TITLE
Remove . from set notation

### DIFF
--- a/logic.rst
+++ b/logic.rst
@@ -186,7 +186,7 @@ We can write a set by listing the elements in between curly braces, like this:
 
 .. math::
 
-  \{1, 2, 3\}.
+  \{1, 2, 3\}
 
 Note that sets have no concept of ordering, so the set :math:`\{1, 3, 2\}` is
 the same as the set :math:`\{1, 2, 3\}`.


### PR DESCRIPTION
Just an extremely minor suggestion - I initially wondered if the dot/period had some significance in the set notation.