### PR TITLE
Exercise 1.7: use `or` instead of `and then`

### DIFF
--- a/logic.rst
+++ b/logic.rst
@@ -172,7 +172,7 @@ same as this bad boy:
    (P \Rightarrow Q) \land (Q \Rightarrow P)
 
 In fact, the standard way of proving a statement of the form :math:`P
-\Leftrightarrow Q` is to first prove :math:`P \Rightarrow Q` and then to prove
+\Leftrightarrow Q` is to prove :math:`P \Rightarrow Q` or
 :math:`Q \Rightarrow P`.
 
 Sets


### PR DESCRIPTION
As I understand `or` is more precise wording here, as `and then` might be considered like `and` meaning both should be true. (or if that's what we is correct then and should be used instead of or in definition)